### PR TITLE
Compatibility for Firefish and other Fediverse software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pem
-database.db
-build
-tlds.dat
 *.tmp
+build
+database.db
+node_modules
+tlds.dat

--- a/src/ActivityPubMessage.ts
+++ b/src/ActivityPubMessage.ts
@@ -1,5 +1,5 @@
 export type ActivityPubMessage<T, O> = {
-  "@context": "https://www.w3.org/ns/activitystreams";
+  "@context": "https://www.w3.org/ns/activitystreams" | any[];
   id: string;
   type: T;
   actor: string;

--- a/src/accept-follow-request.ts
+++ b/src/accept-follow-request.ts
@@ -10,8 +10,13 @@ import { send } from "./send";
 import { ActivityPubMessage } from "./ActivityPubMessage";
 import { serverHostname } from "./env";
 
+const activityStreamsContext = t.union([
+  t.literal("https://www.w3.org/ns/activitystreams"),
+  t.UnknownArray
+]);
+
 const followRequest = t.type({
-  "@context": t.literal("https://www.w3.org/ns/activitystreams"),
+  "@context": activityStreamsContext,
   id: t.string,
   type: t.literal("Follow"),
   actor: t.string, // Follower
@@ -20,7 +25,7 @@ const followRequest = t.type({
 type FollowRequest = t.TypeOf<typeof followRequest>;
 
 const unfollowRequest = t.type({
-  "@context": t.literal("https://www.w3.org/ns/activitystreams"),
+  "@context": activityStreamsContext,
   id: t.string,
   type: t.literal("Undo"),
   actor: t.string, // Follower

--- a/src/send.ts
+++ b/src/send.ts
@@ -22,7 +22,7 @@ export const send = async <Message extends ActivityPubMessage<string, any>>(
   const signature = signer.sign(PRIVATE_KEY);
   const signature_b64 = signature.toString("base64");
   const keyId = `${message.actor}/#main-key`;
-  let header = `keyId="${keyId}",headers="(request-target) host date digest",signature="${signature_b64}"`;
+  let header = `keyId="${keyId}",headers="(request-target) host date digest",algorithm="rsa-sha256",signature="${signature_b64}"`;
 
   const req = await fetch(inbox, {
     headers: {


### PR DESCRIPTION
Mastofeeder currently does not support follow requests from instances running [Firefish](https://joinfirefish.org). This PR makes the changes necessary to provide support for Firefish and potentially other non-Mastodon Fediverse servers:

- `followRequest` and `unfollowRequest` now accept ActivityPub messages where `@context` is an array.

- Message signatures now specify `algorithm=rsa-sha256` as recommended in the [latest HTTP Signatures spec draft](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12#section-2.1.3) and enforced in the [verification library](https://www.npmjs.com/package/@peertube/http-signature) used by Firefish, Peertube, and others.